### PR TITLE
Add a slider to select openai temperature

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -16,6 +16,7 @@ import { eventBus, EventName } from "@/common/event";
 import ChatMessage from "@/components/ChatMessage.vue";
 import OpenaiModelSelector from "@/components/config/OpenaiModelSelector.vue";
 import OpenaiRoleSelector from "@/components/config/OpenaiRoleSelector.vue";
+import OpenaiTemperatureSlider from "@/components/config/OpenaiTemperatureSlider.vue";
 
 const messages = ref<Message[]>([]);
 const newMessage = ref("");
@@ -25,6 +26,7 @@ let received: Ref<Message> = getReceived();
 const isMessageBeingStreamed = ref(false);
 const selectedModel: Ref<OpenaiModel> = ref(OpenaiModel["gpt-3.5-turbo"]);
 const selectedRole: Ref<OpenaiRole> = ref(OpenaiRole.system);
+const selectedTemperature: Ref<Number> = ref(1.0);
 
 function getReceived(): Ref<Message> {
   return ref<Message>({
@@ -41,6 +43,10 @@ function updateOpenaiModel(model: OpenaiModel) {
 
 function updateOpenaiRole(role: OpenaiRole) {
   selectedRole.value = role;
+}
+
+function updateOpenaiTemperature(temperature: number) {
+  selectedTemperature.value = temperature;
 }
 
 async function sendMessage(event: any) {
@@ -70,7 +76,8 @@ async function sendMessage(event: any) {
   newMessage.value = "";
   const prompt = new OpenaiPrompt(
     [new OpenaiMessage(selectedRole.value, messageToSend.text.join(""))],
-    selectedModel.value
+    selectedModel.value,
+    selectedTemperature.value
   );
 
   // Send message and receive stream response
@@ -171,16 +178,21 @@ function onApiKeyError(err: string) {
     </div>
     <div class="chat-textarea">
       <div class="selectbox-area">
-        <openai-model-selector
-          :selected-model="selectedModel"
-          custom-style="mr-2"
-          @update-openai-model="updateOpenaiModel"
-        />
-        <openai-role-selector
-          :selected-role="selectedRole"
-          custom-style="mr-2"
-          @update-openai-role="updateOpenaiRole"
-        />
+        <div>
+          <openai-model-selector
+            :selected-model="selectedModel"
+            custom-style="mr-2"
+            @update-openai-model="updateOpenaiModel"
+          />
+          <openai-role-selector
+            :selected-role="selectedRole"
+            custom-style="mr-2"
+            @update-openai-role="updateOpenaiRole"
+          />
+        </div>
+        <openai-temperature-slider :selected-temperature="selectedTemperature"
+                                   @update-openai-temperature="updateOpenaiTemperature"
+                                   class="temperature" />
       </div>
       <v-textarea
         v-model="newMessage"
@@ -244,6 +256,7 @@ function onApiKeyError(err: string) {
 
 .selectbox-area {
   display: flex;
+  justify-content: space-between;
   align-items: center;
 }
 
@@ -259,4 +272,10 @@ function onApiKeyError(err: string) {
 .message-card-received {
   border-radius: 0 10px 10px 10px;
 }
+
+.temperature {
+  width: 200px;
+  height: 100%;
+}
+
 </style>

--- a/src/components/config/OpenaiTemperatureSlider.vue
+++ b/src/components/config/OpenaiTemperatureSlider.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+
+import { computed } from "vue";
+
+const emits = defineEmits(["updateOpenaiTemperature"]);
+const props = defineProps({
+  selectedTemperature: {
+    type: Number,
+    required: true,
+    default: 1.0
+  }
+});
+const temperature = computed({
+  get() {
+    return props.selectedTemperature;
+  },
+  set(value: number) {
+    emits("updateOpenaiTemperature", parseFloat(value.toFixed(1)));
+  }
+});
+
+const description = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.";
+function getTemperature() {
+  return temperature.value?.toFixed(1);
+}
+
+</script>
+
+<template>
+  <div>
+    <v-slider
+      class="slider"
+      max="2"
+      min="0"
+      v-model="temperature"
+      color="primary"
+      thumb-size="10"
+      track-size="2"
+      :ticks="{ 0: '', 1: '', 2: ''}"
+      show-ticks="always">
+      <template v-slot:append>
+        <div class="temperature-text text-primary">
+          {{ getTemperature() }}
+        </div>
+
+        <div>
+          <v-icon class="ml-1"
+                  color="primary">
+            mdi-thermometer
+          </v-icon>
+          <v-tooltip
+            class="tooltip"
+            width="400"
+            activator="parent"
+            location="left">
+            {{ description }}
+          </v-tooltip>
+        </div>
+      </template>
+    </v-slider>
+  </div>
+</template>
+
+<style scoped>
+
+.slider {
+  font-size: 10px;
+}
+
+.temperature-text {
+  width: 20px;
+  text-align: center;
+}
+
+
+</style>

--- a/src/service/openai.ts
+++ b/src/service/openai.ts
@@ -7,11 +7,13 @@ const MOCK_RESPONSE_STREAM: string[] = "Lorem ipsum dolor sit amet consectetur a
 export class OpenaiPrompt {
   messages: OpenaiMessage[];
   model: OpenaiModel;
-
+  temperature: number;
   constructor(messages: OpenaiMessage[],
-              model: OpenaiModel = OpenaiModel["gpt-3.5-turbo"]) {
+              model: OpenaiModel = OpenaiModel["gpt-3.5-turbo"],
+              temperature: number = 1) {
     this.messages = messages;
     this.model = model;
+    this.temperature = temperature;
   }
 }
 
@@ -101,7 +103,8 @@ const streamOpenAiResponse = appStore().mockOpenai ?
           content: message.content
         })),
         model: prompt.model,
-        stream: true
+        temperature: prompt.temperature,
+        stream: true,
       });
 
       beforeStreamListener();


### PR DESCRIPTION
### Issue Link 
* https://github.com/seonwoo960000/ai-sidebar/issues/44

### Description
* Add a slider to set temperature of openai response. 
* https://platform.openai.com/docs/api-reference/making-requests

### Changes
![image](https://github.com/seonwoo960000/ai-sidebar/assets/69591622/96c6254c-df11-4b6d-aaf1-bf44f7fc605b)
- Slider is added 
- Tooltip is shown(explanation of the temperature) when the icon is being hovered 
