### PR TITLE
Add message template modal 

### DIFF
--- a/src/common/keys.ts
+++ b/src/common/keys.ts
@@ -1,1 +1,11 @@
-export const apiKeyNotFound = Symbol('apiKeyNotFound')
+const apiKeyNotFound = Symbol("apiKeyNotFound");
+
+enum ChromeStorageKeys {
+  API_KEY = "freesidebar_api_key",
+  MESSAGE_TEMPLATE = "freesidebar_message_tempalte"
+}
+
+export {
+  apiKeyNotFound,
+  ChromeStorageKeys
+};

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -17,12 +17,12 @@ import ChatMessage from "@/components/ChatMessage.vue";
 import OpenaiModelSelector from "@/components/config/OpenaiModelSelector.vue";
 import OpenaiRoleSelector from "@/components/config/OpenaiRoleSelector.vue";
 import OpenaiTemperatureSlider from "@/components/config/OpenaiTemperatureSlider.vue";
+import MessageTemplateModal from "@/components/config/MessageTemplateModal.vue";
 
 const messages = ref<Message[]>([]);
 const newMessage = ref("");
 const messageTemplate = ref("")
 const messageTemplateInputPlaceholder = "{{message}}"
-const messageTemplatePlaceholder = `Summarize the following text: ${messageTemplateInputPlaceholder}`
 const scrollTarget: Ref<any> = ref();
 let received: Ref<Message> = getReceived();
 const isMessageBeingStreamed = ref(false);
@@ -37,6 +37,10 @@ function getReceived(): Ref<Message> {
     text: [],
     canceled: false
   });
+}
+
+function updateMessageTemplate(template: string) {
+  messageTemplate.value = template;
 }
 
 function updateOpenaiModel(model: OpenaiModel) {
@@ -194,6 +198,10 @@ function getMessageCardClass(type: string) {
     <div class="chat-textarea">
       <div class="selectbox-area">
         <div>
+          <message-template-modal
+            custom-style="mr-2"
+            @update-message-template="updateMessageTemplate"
+          />
           <openai-model-selector
             :selected-model="selectedModel"
             custom-style="mr-2"
@@ -209,19 +217,6 @@ function getMessageCardClass(type: string) {
                                    @update-openai-temperature="updateOpenaiTemperature"
                                    class="temperature" />
       </div>
-      <v-textarea
-        v-model="messageTemplate"
-        class="preface-textarea"
-        label="Add message template"
-        :placeholder=messageTemplatePlaceholder
-        variant="outlined"
-        rows="1"
-        shaped
-        clearable
-        flat
-        hide-details
-        :disabled="isMessageBeingStreamed"
-      />
       <v-textarea
         v-model="newMessage"
         class="main-textarea"
@@ -245,7 +240,7 @@ function getMessageCardClass(type: string) {
 /* if you want to update the grid-template-rows, you need to update the .chat-message-buttons as well */
 .parent {
   display: grid;
-  grid-template-rows: 1fr 278px;
+  grid-template-rows: 1fr 210px;
   grid-gap: 10px;
   height: 100%;
 
@@ -270,15 +265,14 @@ function getMessageCardClass(type: string) {
 /* because the size of the textbox is 210px from the bottom(refer to .parent), if can fix the position of the buttons by using absolute position */
 .chat-message-buttons {
   position: absolute;
-  bottom: 288px;
+  bottom: 220px;
   left: 50%;
 }
 
 .chat-textarea {
   margin: 0 24px 0 8px;
-
   display: grid;
-  grid-template-rows: 32px 48px 1fr;
+  grid-template-rows: 32px 1fr;
   grid-gap: 16px;
 }
 
@@ -304,9 +298,6 @@ function getMessageCardClass(type: string) {
 .temperature {
   width: 200px;
   height: 100%;
-}
-
-.preface-textarea {
 }
 
 .main-textarea {

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Message } from "@/common/message";
-import { defineComponent, ref, watch } from "vue";
+import { defineComponent, onMounted, ref, watch } from "vue";
 import Markdown from "vue3-markdown-it";
 import MarkdownItHighlightjs from "markdown-it-highlightjs";
 
@@ -44,6 +44,7 @@ watch(props.message, (newValue, oldValue) => {
     <v-card-text class="px-4 py-0">
       <markdown :source="wholeMessage"
                 class="markdown"
+                :breaks="true"
                 :plugins="plugins" />
     </v-card-text>
   </v-card>
@@ -55,7 +56,7 @@ watch(props.message, (newValue, oldValue) => {
 }
 
 .markdown ::v-deep(code) {
-  white-space : pre-wrap !important;
+  white-space: pre-wrap !important;
 }
 
 .markdown ::v-deep(pre) {

--- a/src/components/config/MessageTemplateModal.vue
+++ b/src/components/config/MessageTemplateModal.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+
+import { onMounted, ref, watch } from "vue";
+import { VTextarea } from "vuetify/components";
+import { appStore } from "@/store/app";
+import { ChromeStorageKeys } from "@/common/keys";
+
+const props = defineProps({
+  customStyle: {
+    type: String,
+    default: null
+  }
+});
+
+onMounted(async () => {
+  store.getFromChromeStorage(ChromeStorageKeys.MESSAGE_TEMPLATE)
+    .then(result => {
+      console.log("result: ", result)
+      template.value = result
+    })
+})
+
+const emits = defineEmits(["updateMessageTemplate"]);
+
+const store = appStore();
+const dialog = ref(false);
+const template = ref("");
+const messageTemplateInputPlaceholder = "{{message}}";
+const messageTemplatePlaceholder = `Summarize the following text: ${messageTemplateInputPlaceholder}`;
+
+watch(template, (newVal) => {
+  if (newVal) {
+    store.saveToChromeStorage(ChromeStorageKeys.MESSAGE_TEMPLATE, newVal);
+    emits("updateMessageTemplate", newVal);
+  }
+});
+
+</script>
+
+<template>
+  <v-btn size="x-small"
+         prepend-icon="mdi-account-outline"
+         rounded
+         variant="outlined"
+         color="primary"
+         :class="customStyle"
+         v-bind="props"
+         @click="dialog = !dialog">
+    Template
+    <v-dialog class="dialog"
+              v-model="dialog"
+              :scrim="false">
+      <v-card>
+        <v-toolbar dark
+                   color="primary">
+          <v-btn icon
+                 dark
+                 @click="dialog=false">
+            <v-icon>
+              mdi-close
+            </v-icon>
+          </v-btn>
+          <v-toolbar-title>Message Template</v-toolbar-title>
+        </v-toolbar>
+        <v-container class="fill-height">
+          <v-responsive class="fill-height pa-6">
+            <v-textarea
+              v-model="template"
+              :placeholder="messageTemplatePlaceholder"
+              class="mb-6"
+              variant="outlined"
+              shaped
+              clearable
+              flat
+              hide-details
+            />
+            <v-card color="primary"
+                    variant="tonal">
+              <v-card-item class="mt-2">
+                <template v-slot:subtitle>
+                  Note
+                </template>
+              </v-card-item>
+              <v-card-text class="text-medium-emphasis text-caption">
+                Message will be formatted by using the message template if configured.
+                <span>{{messageTemplateInputPlaceholder}}</span> is a placeholder for the original message.
+              </v-card-text>
+            </v-card>
+          </v-responsive>
+        </v-container>
+      </v-card>
+    </v-dialog>
+  </v-btn>
+</template>
+
+<style scoped>
+
+.dialog {
+  width: 80%;
+}
+
+</style>

--- a/src/service/openai.ts
+++ b/src/service/openai.ts
@@ -1,7 +1,17 @@
 import { appStore } from "@/store/app";
 
 const mockOpenaiApiResponseInterval: number = appStore().mockOpenaiApiResponseInterval;
-const MOCK_RESPONSE_STREAM: string[] = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Maxime mollitia, molestiae quas vel sint commodi repudiandae consequuntur voluptatum laborum numquam blanditiis harum quisquam eius sed odit fugiat iusto fuga praesentium optio, eaque rerum! Provident similique accusantium nemo autem. Veritatis obcaecati tenetur iure eius earum ut molestias architecto voluptate aliquam nihil, eveniet aliquid culpa officia aut! Impedit sit sunt quaerat, odit, tenetur error, harum nesciunt ipsum debitis quas aliquid. Reprehenderit, quia. Quo neque error repudiandae fuga? Ipsa laudantium molestias eos sapiente officiis modi at sunt excepturi expedita sint? Sed quibusdam recusandae alias error harum maxime adipisci amet laborum. Perspiciatis minima nesciunt dolorem! Officiis iure rerum voluptates a cumque velit quibusdam sed amet tempora. Sit laborum ab, eius fugit doloribus tenetur fugiat, temporibus enim commodi iusto libero magni deleniti quod quam consequuntur! Commodi minima excepturi repudiandae velit hic maxime doloremque. Quaerat provident commodi consectetur veniam similique ad earum omnis ipsum saepe, voluptas, hic voluptates pariatur est explicabo fugiat, dolorum eligendi quam cupiditate excepturi mollitia maiores labore suscipit quas? Nulla, placeat. Voluptatem quaerat non architecto ab laudantium modi minima sunt esse temporibus sint culpa, recusandae aliquam numquam totam ratione voluptas quod exercitationem fuga. Possimus quis earum veniam quasi aliquam eligendi, placeat qui corporis!"
+const MOCK_RESPONSE_STREAM: string[] = ("Lorem ipsum dolor sit amet consectetur adipisicing elit. " +
+  "Maxime mollitia, molestiae quas vel sint commodi repudiandae consequuntur voluptatum laborum numquam " +
+  "blanditiis harum quisquam eius sed odit fugiat iusto fuga praesentium optio, eaque rerum! Provident " +
+  "laudantium molestias eos sapiente officiis modi at sunt excepturi expedita sint? Sed quibusdam recusandae.\n " +
+  "```java\n" +
+  "public class HelloWorld {\n" +
+  "    public static void main(String[] args) {\n" +
+  "        System.out.println(\"Hello, world!\");\n" +
+  "    }\n" +
+  "}\n" +
+  "```")
   .split(" ");
 
 export class OpenaiPrompt {


### PR DESCRIPTION
### Issue Link 
* https://github.com/seonwoo960000/ai-sidebar/issues/56

### Description
* A modal in which users can add message template is added 
![image](https://github.com/seonwoo960000/ai-sidebar/assets/69591622/d8e72dbf-d032-4285-ad09-97af94ea31b9)


### Changes
* A modal for message template is added. 
* Line breaks are maintained in the chat message areas 
